### PR TITLE
Fix achievements plugin

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: left
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
           # Your GitHub token
           token: ${{ secrets.METRICS_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
           config_order: followup, languages, stargazers
 
       - name: right
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
           token: ${{ secrets.METRICS_TOKEN }}
           filename: metrics.right.svg
@@ -65,5 +65,7 @@ jobs:
           plugin_achievements: yes
           plugin_achievements_secrets: yes
           plugin_achievements_threshold: D
+          plugin_achievements_display: detailed
+          plugin_achievements_limit: 0
           #plugin_achievements_ignored: member, worker, explorer, automator, infographile
 


### PR DESCRIPTION
## Summary
- pin metrics action version to v3.34
- tweak achievements plugin configuration to output a detailed view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684273b74d68832bac093ad768230b39